### PR TITLE
Translated behaviour name into Swedish

### DIFF
--- a/lang/sv/qbehaviour_dfcbmexplicitvaildate.php
+++ b/lang/sv/qbehaviour_dfcbmexplicitvaildate.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Strings for component 'qbehaviour_dfcbmexplicitvaildate', language 'en'.
+ * Strings for component 'qbehaviour_dfcbmexplicitvaildate', language 'sv'.
  *
  * @package    qbehaviour_dfcbmexplicitvaildate
  * @copyright  2012 The Open University


### PR DESCRIPTION
I realize this is kind of silly, but I want to have the parts of Moodle that I use in Swedish. Sorry for two commits, but I pushed it to origin before noticing...
